### PR TITLE
feat: API endpoint to notify donation payment failures

### DIFF
--- a/iff/iff/install.py
+++ b/iff/iff/install.py
@@ -5,6 +5,23 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
 def after_install():
 	create_e_mandate_custom_fields()
+
+	create_custom_field('Non Profit Settings', {
+		'label': _('Notify Payment Failures'),
+		'fieldname': 'notify_donation_payment_failures',
+		'fieldtype': 'Check',
+		'insert_after': 'donation_payment_account'
+	})
+	create_custom_field('Non Profit Settings', {
+		'label': _('Email Template'),
+		'fieldname': 'email_template_for_failure',
+		'fieldtype': 'Link',
+		'options': 'Email Template',
+		'depends_on': 'notify_donation_payment_failures',
+		'mandatory_depends_on': 'notify_donation_payment_failures',
+		'insert_after': 'notify_donation_payment_failures'
+	})
+
 	frappe.db.commit()
 
 def create_e_mandate_custom_fields():


### PR DESCRIPTION
## Non-Profit Settings

Added a setting to notify donors about payment failures and the email template for the message.

<img width="516" alt="image" src="https://user-images.githubusercontent.com/24353136/156421639-3611c117-f76c-4502-9082-14b81cdcb131.png">
 
## API Endpoint

Added an API endpoint `notify_donation_payment_failures` to notify donors about payment failures. This API will be called from a Razorpay webhook on `payment.failure` event.

Also fixed signature verification errors occurring due to modification of `data`